### PR TITLE
hotfix:猫プロフィール画面編集のバク修正

### DIFF
--- a/app/Http/Controllers/Administrator/cats/Delete/DeleteController.php
+++ b/app/Http/Controllers/Administrator/cats/Delete/DeleteController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Administrator\cats\Delete;
 
 use App\Http\Controllers\Controller;
 use App\Models\Cat;
-use App\Http\Requests\Administrator\cats\CatsRequest;
+use Illuminate\Http\Request;
 
 class DeleteController extends Controller
 {
@@ -14,7 +14,7 @@ class DeleteController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function __invoke(CatsRequest $request)
+    public function __invoke(Request $request)
     {
         $cat = Cat::where('id', $request->id())->firstOrFail();
         $cat->delete();

--- a/app/Http/Controllers/Administrator/cats/Update/IndexController.php
+++ b/app/Http/Controllers/Administrator/cats/Update/IndexController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Administrator\cats\Update;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Administrator\cats\CatsRequest;
+use Illuminate\Http\Request;
 use App\Models\Cat;
 
 class IndexController extends Controller
@@ -14,7 +14,7 @@ class IndexController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function __invoke(CatsRequest $request)
+    public function __invoke(Request $request)
     {
         $cat = Cat::where('id', $request->id())->firstOrFail();
         $catViewData = [

--- a/app/Http/Controllers/Administrator/cats/Update/PutController.php
+++ b/app/Http/Controllers/Administrator/cats/Update/PutController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Administrator\cats\Update;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Administrator\cats\CatsRequest;
+use Illuminate\Http\Request;
 use App\Models\Cat;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\DB;
@@ -17,7 +17,7 @@ class PutController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */    
-    public function __invoke(CatsRequest $request)
+    public function __invoke(Request $request)
     {
         $cat = Cat::where('id', $request->id())->firstOrFail();
 


### PR DESCRIPTION
# 解決したい課題
猫プロフィール画面にて、編集・削除ボタンをクリックすると意図しないバリデーション画面の表示がでること。

# 課題解決策
バリデーションを行っているCatsRequestクラスを編集と削除を行っているControllerから削除しRequestクラスへ変更する

# 変更点
- Update/IndexController.php、Update/PutController.php、Delete/DeleteController.phpファイルの
`use App\Http\Requests\Administrator\cats\CatsRequest;`を`use Illuminate\Http\Request;`へ変更。
- 影響範囲の`__invoke(CatsRequest $request)`を`__invoke(Request $request)`へ変更。

